### PR TITLE
do not calculate scales on render in frozen components

### DIFF
--- a/src/components/grouped-bar/GroupedBarView.js
+++ b/src/components/grouped-bar/GroupedBarView.js
@@ -72,7 +72,8 @@ export default class GroupedBarView extends ChartView {
   render () {
     super.render()
     this._onMouseout()
-    this.calculateScales()
+    // frozen component is completely controlled from outside
+    if (!this.config.get('frozen')) this.calculateScales()
 
     // Create a flat data structure
     const numOfAccessors = _.keys(this.config.yAccessors).length

--- a/src/components/line/LineView.js
+++ b/src/components/line/LineView.js
@@ -56,7 +56,8 @@ export default class LineView extends ChartView {
    */
   render () {
     super.render()
-    this.calculateScales()
+    // frozen component is completely controlled from outside
+    if (!this.config.get('frozen')) this.calculateScales()
     const data = this.model.data
     const xAccessor = this.config.get('x.accessor')
     const accessor = this.config.get('y')

--- a/src/components/stacked-bar/StackedBarView.js
+++ b/src/components/stacked-bar/StackedBarView.js
@@ -74,7 +74,8 @@ export default class StackedBarView extends ChartView {
   render () {
     super.render()
     this._onMouseout()
-    this.calculateScales()
+    // frozen component is completely controlled from outside
+    if (!this.config.get('frozen')) this.calculateScales()
 
     const start = this.config.yScale.range()[0]
     const barGroups = this.d3


### PR DESCRIPTION
if component is frozen, it is operated by parent and setting scales will be performed on upper level. This is required in order to be able to sync scales of different components